### PR TITLE
A few fixes for the "rise" animation.

### DIFF
--- a/jquery.flipper.css
+++ b/jquery.flipper.css
@@ -140,11 +140,11 @@
 
 /* Rise Transition */
 .flipper.fl-rise.fl-go .fl-show.fl-bottom {
-    -moz-transform: perspective(500px) rotatex(-90deg);
-    -ms-transform: perspective(500px) rotatex(-90deg);
-    -o-transform: perspective(500px) rotatex(-90deg);
-    -webkit-transform: perspective(500px) rotatex(-90deg);
-    transform: perspective(500px) rotatex(-90deg)
+    -moz-transform: perspective(500px) rotatex(90deg);
+    -ms-transform: perspective(500px) rotatex(90deg);
+    -o-transform: perspective(500px) rotatex(90deg);
+    -webkit-transform: perspective(500px) rotatex(90deg);
+    transform: perspective(500px) rotatex(90deg)
     }
 
 .flipper.fl-rise.fl-go .fl-new.fl-top {

--- a/jquery.flipper.novendors.css
+++ b/jquery.flipper.novendors.css
@@ -85,11 +85,11 @@
 /* Rise Transition */
 
 .flipper.fl-rise.fl-go .fl-show.fl-bottom{
-    transform: perspective(500px) rotateX(-90deg);
+    transform: perspective(500px) rotateX(90deg);
 }
 
 .flipper.fl-rise.fl-go .fl-new.fl-top {
-    transform: perspective(500px) rotateX(-0deg);
+    transform: perspective(500px) rotateX(0deg);
 }
 
 .flipper.fl-rise .fl-new.fl-top {


### PR DESCRIPTION
Hi, thanks for the nice library!
I found two issues with the "rise" animation which I had to fix for my project, so I hope you find it useful and integrate it in your repo.

Both issues can be reproduced at the current version of this page: http://mrkmg.com/flipper/
- Safari-only: animation was not showing at all in the bottom half of the number container.
- All browsers: the turning page was smaller during the animation in the bottom half of the number container.
